### PR TITLE
Fixed a couple of bugs

### DIFF
--- a/ssd_channel.cpp
+++ b/ssd_channel.cpp
@@ -196,12 +196,14 @@ void Channel::unlock(double start_time)
 {
 	/* remove expired channel lock entries */
 	std::vector<lock_times>::iterator it;
-	for ( it = timings.begin(); it < timings.end(); it++)
+	for ( it = timings.begin(); it < timings.end();)
 	{
 		if((*it).unlock_time <= start_time)
 			timings.erase(it);
 		else
-			break;
+		{
+			it++;
+		}
 	}
 	std::sort(timings.begin(), timings.end(), &timings_sorter);
 }

--- a/ssd_controller.cpp
+++ b/ssd_controller.cpp
@@ -98,7 +98,7 @@ enum status Controller::issue(Event &event_list)
 			assert(cur -> get_address().valid > NONE);
 			if(ssd.bus.lock(cur -> get_address().package, cur -> get_start_time(), BUS_CTRL_DELAY, *cur) == FAILURE
 				|| ssd.read(*cur) == FAILURE
-				|| ssd.bus.lock(cur -> get_address().package, cur -> get_start_time(), BUS_CTRL_DELAY + BUS_DATA_DELAY, *cur) == FAILURE
+				|| ssd.bus.lock(cur -> get_address().package, cur -> get_time_taken(), BUS_CTRL_DELAY + BUS_DATA_DELAY, *cur) == FAILURE
 				|| ssd.ram.write(*cur) == FAILURE
 				|| ssd.ram.read(*cur) == FAILURE
 				|| ssd.replace(*cur) == FAILURE)


### PR DESCRIPTION
In ssd_channel.cpp, in the unlock function. If the vector element is erased, then the iterator must not be incremented

In ssd_controller.cpp, when locking the bus for transferring data during the read, the lock request start time should be set to the current time (which includes the time for the previous lock of the bus and the time for reading the data into the register) and not the lock request start time  