### PR TITLE
update ssd_ssd.cpp: Ssd::replace

### DIFF
--- a/ssd_ssd.cpp
+++ b/ssd_ssd.cpp
@@ -204,6 +204,8 @@ enum status Ssd::write(Event &event)
 
 enum status Ssd::replace(Event &event)
 {
+	if(event.get_replace_address().valid == NONE)
+		return SUCCESS;
 	assert(data != NULL && event.get_replace_address().package < size);
 	if (event.get_replace_address().valid == PAGE)
 		return data[event.get_replace_address().package].replace(event);


### PR DESCRIPTION
If the LPN(logical page number) is first visited, the `replace_address` of the event is NONE. So, we should do nothing in the `ssd::replace()`.